### PR TITLE
Don't cap ends of a zero-length progress bar

### DIFF
--- a/progress-ring-view/src/main/java/flepsik/github/com/progress_ring/ProgressRingView.java
+++ b/progress-ring-view/src/main/java/flepsik/github/com/progress_ring/ProgressRingView.java
@@ -384,7 +384,7 @@ public class ProgressRingView extends View {
             paint.setStyle(Paint.Style.STROKE);
             canvas.drawArc(rect, START_ANGLE, sweepAngle, false, paint);
             paint.setStyle(Paint.Style.FILL);
-            if (shouldCornerEdges) {
+            if (shouldCornerEdges && sweepAngle > 0) {
                 canvas.drawCircle(startCircle.x, startCircle.y, ringWidth / 2, paint);
                 canvas.drawCircle(endCircle.x, endCircle.y, ringWidth / 2, paint);
             }


### PR DESCRIPTION
If the progress is set to zero but corner edges is enabled, the caps
will be drawn, resulting in a progress bar that appears to be > 0.

Before & after:
![before_after](https://user-images.githubusercontent.com/2476799/32954668-c2a04fda-cb81-11e7-85ce-d4873aad22a6.png)
